### PR TITLE
Resolved #14

### DIFF
--- a/example/addons/keel-echo.py
+++ b/example/addons/keel-echo.py
@@ -5,7 +5,7 @@ app = Flask(__name__)
 @app.route('/v1/identify',methods=['GET'])
 def identify():
     print("identify", flush=True)
-    return jsonify({"ret": 0,"msg": "ok","plugin_id": "keel-echo","version": "0.0.1","main_plugins": [{"id": "keel","version": "1.0","endpoints": [{"addons_point": "externalPreRouteCheck","endpoint": "echo"}]}]})
+    return jsonify({"ret": 0,"msg": "ok","plugin_id": "keel-echo","version": "0.0.1","tkeel_version":"v0.1.0","main_plugins": [{"id": "keel","version": "1.0","endpoints": [{"addons_point": "externalPreRouteCheck","endpoint": "echo"}]}]})
 
 @app.route('/v1/status',methods=['GET'])
 def status():

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -17,7 +17,8 @@ var (
 
 // Configuration is required by all plug-ins in keel.
 type Configuration struct {
-	Plugin PluginSpec `json:"plugin,omitempty" yaml:"plugin,omitempty"`
+	Plugin *PluginSpec `json:"plugin,omitempty" yaml:"plugin,omitempty"`
+	Tkeel  *TkeelSpec  `json:"tkeel,omitempty" yaml:"tkeel,omitempty"`
 }
 
 // PluginSpec describes plugin information.
@@ -27,12 +28,17 @@ type PluginSpec struct {
 	Port    int    `json:"port" yaml:"port"`
 }
 
+type TkeelSpec struct {
+	Version string `json:"version" yaml:"version"`
+}
+
 // LoadDefaultConfiguration returns the default config.
 func LoadDefaultConfiguration() *Configuration {
 	return &Configuration{
-		Plugin: PluginSpec{
+		Plugin: &PluginSpec{
 			Port: DefaultHTTPPort,
 		},
+		Tkeel: &TkeelSpec{},
 	}
 }
 

--- a/pkg/keel/model.go
+++ b/pkg/keel/model.go
@@ -50,6 +50,7 @@ type Plugin struct {
 
 type PluginRoute struct {
 	Status         openapi.PluginStatus `json:"status"`
+	TkeelVersion   string               `json:"tkeel_version"`
 	RegisterAddons map[string]string    `json:"register_addons,omitempty"`
 }
 

--- a/pkg/keel/verison.go
+++ b/pkg/keel/verison.go
@@ -1,0 +1,87 @@
+package keel
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Version struct {
+	Main     int
+	Sub      int
+	Revision int
+}
+
+type ComparisonLevel int
+
+const (
+	MainVersion     ComparisonLevel = 0
+	SubVersion      ComparisonLevel = 1
+	RevisionVersion ComparisonLevel = 2
+)
+
+func NewVersion(ver string) (*Version, error) {
+	if !strings.HasPrefix(ver, "v") {
+		return nil, fmt.Errorf("wrong format: %s", ver)
+	}
+	vs := strings.Split(strings.TrimPrefix(ver, "v"), ".")
+	if len(vs) != 3 {
+		return nil, fmt.Errorf("wrong format: %s", ver)
+	}
+	m, err := strconv.Atoi(vs[0])
+	if err != nil {
+		return nil, fmt.Errorf("wrong format main: %s/%s", vs[0], ver)
+	}
+	s, err := strconv.Atoi(vs[1])
+	if err != nil {
+		return nil, fmt.Errorf("wrong format sub: %s/%s", vs[1], ver)
+	}
+	r, err := strconv.Atoi(vs[2])
+	if err != nil {
+		return nil, fmt.Errorf("wrong format revision: %s/%s", vs[2], ver)
+	}
+	return &Version{
+		Main:     m,
+		Sub:      s,
+		Revision: r,
+	}, nil
+}
+
+func (v *Version) Compare(ver *Version, lvl ComparisonLevel) int {
+	cmpFunc := func(ahead bool, eq bool) int {
+		if ahead {
+			return 1
+		}
+		if eq {
+			return 0
+		}
+		return -1
+	}
+	if v.Main != ver.Main || lvl == MainVersion {
+		return cmpFunc(v.Main > ver.Main, v.Main == ver.Main)
+	}
+	if v.Sub != ver.Sub || lvl == SubVersion {
+		return cmpFunc(v.Sub > ver.Sub, v.Sub == ver.Sub)
+	}
+	if v.Revision != ver.Revision || lvl == RevisionVersion {
+		return cmpFunc(v.Revision > ver.Revision, v.Revision == ver.Revision)
+	}
+	return 0
+}
+
+func CheckRegisterPluginTkeelVersion(dependVersion string, currVersion string) bool {
+	dVer, err := NewVersion(dependVersion)
+	if err != nil {
+		log.Errorf("error depend version: %s", err)
+		return false
+	}
+	cVer, err := NewVersion(currVersion)
+	if err != nil {
+		log.Errorf("error current version: %s", err)
+		return false
+	}
+	if cVer.Compare(dVer, SubVersion) < 0 {
+		return false
+	}
+	return true
+}

--- a/pkg/openapi/openapi.go
+++ b/pkg/openapi/openapi.go
@@ -13,6 +13,7 @@ type Openapi struct {
 	port         int
 	pluginID     string
 	version      string
+	tkeelVersion string
 	requiredFunc struct {
 		Identify   func() (*IdentifyResp, error)
 		Status     func() (*StatusResp, error)
@@ -37,11 +38,12 @@ type OptionalFunc struct {
 	AddonsIdentify func(*AddonsIdentifyReq) (*AddonsIdentifyResp, error)
 }
 
-func NewOpenapi(port int, id, ver string) *Openapi {
+func NewOpenapi(port int, id, ver, tkeelVer string) *Openapi {
 	return &Openapi{
 		port:           port,
 		pluginID:       id,
 		version:        ver,
+		tkeelVersion:   tkeelVer,
 		mux:            http.NewServeMux(),
 		registerAPIMap: make(map[string]*API),
 	}
@@ -93,6 +95,7 @@ func (a *Openapi) GetIdentifyResp() *IdentifyResp {
 		CommonResult: SuccessResult(),
 		PluginID:     a.pluginID,
 		Version:      a.version,
+		TkeelVersion: a.tkeelVersion,
 	}
 }
 

--- a/pkg/openapi/openapi_test.go
+++ b/pkg/openapi/openapi_test.go
@@ -14,12 +14,12 @@ import (
 var o *Openapi
 
 func newOprator() {
-	o = NewOpenapi(8080, "keel-hello", "1.0")
+	o = NewOpenapi(8080, "keel-hello", "1.0", "v0.1.0")
 }
 
 func TestNewOprator(t *testing.T) {
 	t.Run("test create oprator", func(t *testing.T) {
-		o = NewOpenapi(8080, "keel-hello", "1.0")
+		o = NewOpenapi(8080, "keel-hello", "1.0", "v0.1.0")
 		assert.NotNil(t, o)
 		assert.NoError(t, o.Close())
 	})
@@ -35,6 +35,7 @@ func TestOpratorIdentify(t *testing.T) {
 		assert.Equal(t, iresp.Msg, "ok")
 		assert.Equal(t, iresp.PluginID, "keel-hello")
 		assert.Equal(t, iresp.Version, "1.0")
+		assert.Equal(t, iresp.TkeelVersion, "v0.1.0")
 		assert.Nil(t, iresp.AddonsPoints)
 		assert.Nil(t, iresp.MainPlugins)
 		assert.NoError(t, o.Close())
@@ -93,6 +94,7 @@ func TestDefaultOpratorHttpMethod(t *testing.T) {
 		assert.Equal(t, iresp.Msg, "ok")
 		assert.Equal(t, iresp.PluginID, "keel-hello")
 		assert.Equal(t, iresp.Version, "1.0")
+		assert.Equal(t, iresp.TkeelVersion, "v0.1.0")
 		assert.Nil(t, iresp.AddonsPoints)
 		assert.Nil(t, iresp.MainPlugins)
 

--- a/pkg/plugin/keel/api.go
+++ b/pkg/plugin/keel/api.go
@@ -45,7 +45,7 @@ func (k *Keel) Route(e *openapi.APIEvent) {
 	}
 
 	// check upstream plugin.
-	err = checkPluginStatus(e.HTTPReq.Context(), upPluginID)
+	err = checkUpstreamPlugin(e.HTTPReq.Context(), pID, upPluginID)
 	if err != nil {
 		log.Errorf("error check plugin(%s) status: %s", upPluginID, err)
 		http.Error(e, "bad request", http.StatusBadRequest)

--- a/pkg/plugin/keel/keel.go
+++ b/pkg/plugin/keel/keel.go
@@ -55,6 +55,7 @@ func (k *Keel) identify() (*openapi.IdentifyResp, error) {
 		CommonResult: openapi.SuccessResult(),
 		PluginID:     k.p.GetIdentifyResp().PluginID,
 		Version:      k.p.GetIdentifyResp().Version,
+		TkeelVersion: k.p.Conf().Tkeel.Version,
 		AddonsPoints: []*openapi.AddonsPoint{
 			{
 				AddonsPoint: "externalPreRouteCheck",

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -13,9 +13,7 @@ import (
 	"github.com/tkeel-io/tkeel/pkg/version"
 )
 
-var (
-	log = logger.NewLogger("keel.plugin")
-)
+var log = logger.NewLogger("keel.plugin")
 
 type Plugin struct {
 	conf *keelconfig.Configuration
@@ -24,11 +22,12 @@ type Plugin struct {
 
 func FromFlags() (*Plugin, error) {
 	pluginID := flag.String("plugin-id", utils.GetEnv("PLUGIN_ID", "keel-hello"), "Plugin id")
-	pluginVersion := flag.String("plugin-version", utils.GetEnv("PLUGIN_VERSION", version.Version()), "Plugin version")
+	pluginVersion := flag.String("plugin-version", utils.GetEnv("PLUGIN_VERSION", version.Version()), "Plugin version.")
+	tkeelVersion := flag.String("tkeel-version", utils.GetEnv("TKEEL_VERSION", version.Version()), "The version of tkeel the plugin depends on.")
 	defaultPluginHTTPPort, _ := strconv.Atoi(utils.GetEnv("PLUGIN_HTTP_PORT", "8080"))
-	pluginHTTPPort := flag.Int("plugin-http-port", defaultPluginHTTPPort, "The port that the plugin listens to")
-	daprPort := flag.String("dapr-http-port", utils.GetEnv("DAPR_HTTP_PORT", "3500"), "The port that the dapr listens to")
-	config := flag.String("keel-plugin-config", utils.GetEnv("KEEL_PLUGIN_CONFIG", ""), "Path to config file, or name of a configuration object")
+	pluginHTTPPort := flag.Int("plugin-http-port", defaultPluginHTTPPort, "The port that the plugin listens to.")
+	daprPort := flag.String("dapr-http-port", utils.GetEnv("DAPR_HTTP_PORT", "3500"), "The port that the dapr listens to.")
+	config := flag.String("keel-plugin-config", utils.GetEnv("KEEL_PLUGIN_CONFIG", ""), "Path to config file, or name of a configuration object.")
 
 	flag.Parse()
 
@@ -50,10 +49,12 @@ func FromFlags() (*Plugin, error) {
 		conf.Plugin.ID = *pluginID
 		conf.Plugin.Port = *pluginHTTPPort
 		conf.Plugin.Version = *pluginVersion
+		conf.Tkeel.Version = *tkeelVersion
 		newPlugin.conf = conf
 	}
 
-	newPlugin.Openapi = openapi.NewOpenapi(newPlugin.conf.Plugin.Port, newPlugin.conf.Plugin.ID, newPlugin.conf.Plugin.Version)
+	newPlugin.Openapi = openapi.NewOpenapi(newPlugin.conf.Plugin.Port, newPlugin.conf.Plugin.ID,
+		newPlugin.conf.Plugin.Version, newPlugin.conf.Tkeel.Version)
 	return newPlugin, nil
 }
 

--- a/pkg/plugin/plugins/api.go
+++ b/pkg/plugin/plugins/api.go
@@ -210,7 +210,7 @@ func (ps *Plugins) RegisterPlugins(e *openapi.APIEvent) {
 		return
 	}
 
-	err = registerPlugin(e.HTTPReq.Context(), identifyResp, secret)
+	err = registerPlugin(e.HTTPReq.Context(), identifyResp, secret, ps.p.Conf().Tkeel.Version)
 	if err != nil {
 		log.Errorf("error register plugins: %s", err)
 		http.Error(e, "error register", http.StatusInternalServerError)

--- a/pkg/plugin/plugins/plugins.go
+++ b/pkg/plugin/plugins/plugins.go
@@ -83,7 +83,7 @@ func (ps *Plugins) Run() {
 	}
 	log.Debugf("dapr ready: %s", time.Now().Format(time.RFC3339Nano))
 
-	err := registerPlugin(context.TODO(), ps.p.GetIdentifyResp(), *pluginTokenSecret)
+	err := registerPlugin(context.TODO(), ps.p.GetIdentifyResp(), *pluginTokenSecret, ps.p.Conf().Tkeel.Version)
 	if err != nil {
 		log.Debugf("error register plugin plugins: %s, If its a duplicate registration error, you can ignore it", err)
 	}


### PR DESCRIPTION
The platform version is equal to the core plugin version, and the core plugin versions are consistent with each other.(the core plugin consists of keel, auth and plugins.)

- Check the dependent platform version when the plugin registering.
- Check dependencies when plugins call each other through **Keel**.

Close #14 